### PR TITLE
update frag_dict to match GUI modes

### DIFF
--- a/napari/_vispy/volume.py
+++ b/napari/_vispy/volume.py
@@ -56,7 +56,7 @@ MINIP_SNIPPETS = dict(
 
 MINIP_FRAG_SHADER = FRAG_SHADER.format(**MINIP_SNIPPETS)
 
-frag_dict['MinIP'] = MINIP_FRAG_SHADER
+frag_dict['minip'] = MINIP_FRAG_SHADER
 
 
 # Custom volume class is needed for better 3D rendering


### PR DESCRIPTION
# Description

Hi @alisterburt! While trying out napari/napari#1861 (which is awesome), I noticed that changing the rendering mode in the GUI did nothing, and traced it down to this case spelling mismatch. I like all lowercase for consistency with the remaining modes.