### PR TITLE
fix tests, change view_direction behavior

### DIFF
--- a/napari/_vispy/_tests/test_utils.py
+++ b/napari/_vispy/_tests/test_utils.py
@@ -49,3 +49,22 @@ def test_get_view_direction_in_scene_coordinates(make_napari_viewer):
         view_box, viewer.dims.point, viewer.dims.displayed
     )
     np.testing.assert_allclose(view_dir, [1, 0, 0], atol=1e-8)
+
+
+def test_get_view_direction_in_scene_coordinates_2d(make_napari_viewer):
+    """view_direction should be None in 2D"""
+    viewer = make_napari_viewer()
+
+    # reset view sets the camera angles to (0, 0, 90)
+    viewer.dims.ndim = 3
+    viewer.dims.ndisplay = 2
+
+    # get the viewbox
+    view_box = viewer.window.qt_viewer.view
+
+    # get the view direction
+    view_dir = get_view_direction_in_scene_coordinates(
+        view_box, viewer.dims.point, viewer.dims.displayed
+    )
+
+    assert view_dir is None

--- a/napari/_vispy/utils.py
+++ b/napari/_vispy/utils.py
@@ -75,8 +75,10 @@ def get_view_direction_in_scene_coordinates(
     dims_point: Tuple[int],
     dims_displayed: Tuple[int],
 ) -> np.ndarray:
-    """calculate the unit vector pointing in the direction of the view
+    """Calculate the unit vector pointing in the direction of the view.
 
+    This is only for 3D viewing, so it returns None when
+    len(dims_displayed) == 2.
     Adapted From:
     https://stackoverflow.com/questions/37877592/
         get-view-direction-relative-to-scene-in-vispy/37882984
@@ -96,31 +98,36 @@ def get_view_direction_in_scene_coordinates(
     -------
     view_vector : np.ndarray
         Unit vector in the direction of the view in scene coordinates.
-        Axes are ordered zyx.
+        Axes are ordered zyx. If the viewer is in 2D
+        (i.e., len(dims_displayed) == 2), view_vector is None.
     """
-    tform = view.scene.transform
-    w, h = view.canvas.size
+    if len(dims_displayed) == 3:
+        # only return a vector when viewing in 3D
+        tform = view.scene.transform
+        w, h = view.canvas.size
 
-    # get a point at the center of the canvas
-    # (homogeneous screen coords)
-    screen_center = np.array([w / 2, h / 2, 0, 1])
+        # get a point at the center of the canvas
+        # (homogeneous screen coords)
+        screen_center = np.array([w / 2, h / 2, 0, 1])
 
-    # find a point just in front of the center point
-    # transform both to world coords and find the vector
-    d1 = np.array([0, 0, 1, 0])
-    point_in_front_of_screen_center = screen_center + d1
-    p1 = tform.imap(point_in_front_of_screen_center)
-    p0 = tform.imap(screen_center)
-    d2 = p1 - p0
+        # find a point just in front of the center point
+        # transform both to world coords and find the vector
+        d1 = np.array([0, 0, 1, 0])
+        point_in_front_of_screen_center = screen_center + d1
+        p1 = tform.imap(point_in_front_of_screen_center)
+        p0 = tform.imap(screen_center)
+        d2 = p1 - p0
 
-    # in 3D world coordinates
-    d3 = d2[0:3]
-    d4 = d3 / np.linalg.norm(d3)
+        # in 3D world coordinates
+        d3 = d2[0:3]
+        d4 = d3 / np.linalg.norm(d3)
 
-    # data are ordered xyz on vispy Volume
-    d4 = d4[[2, 1, 0]]
-    view_dir_world = list(dims_point)
-    for i, d in enumerate(dims_displayed):
-        view_dir_world[d] = d4[i]
+        # data are ordered xyz on vispy Volume
+        d4 = d4[[2, 1, 0]]
+        view_dir_world = list(dims_point)
+        for i, d in enumerate(dims_displayed):
+            view_dir_world[d] = d4[i]
 
-    return view_dir_world
+        return view_dir_world
+    else:
+        return None

--- a/napari/_vispy/utils.py
+++ b/napari/_vispy/utils.py
@@ -101,33 +101,33 @@ def get_view_direction_in_scene_coordinates(
         Axes are ordered zyx. If the viewer is in 2D
         (i.e., len(dims_displayed) == 2), view_vector is None.
     """
-    if len(dims_displayed) == 3:
-        # only return a vector when viewing in 3D
-        tform = view.scene.transform
-        w, h = view.canvas.size
-
-        # get a point at the center of the canvas
-        # (homogeneous screen coords)
-        screen_center = np.array([w / 2, h / 2, 0, 1])
-
-        # find a point just in front of the center point
-        # transform both to world coords and find the vector
-        d1 = np.array([0, 0, 1, 0])
-        point_in_front_of_screen_center = screen_center + d1
-        p1 = tform.imap(point_in_front_of_screen_center)
-        p0 = tform.imap(screen_center)
-        d2 = p1 - p0
-
-        # in 3D world coordinates
-        d3 = d2[0:3]
-        d4 = d3 / np.linalg.norm(d3)
-
-        # data are ordered xyz on vispy Volume
-        d4 = d4[[2, 1, 0]]
-        view_dir_world = list(dims_point)
-        for i, d in enumerate(dims_displayed):
-            view_dir_world[d] = d4[i]
-
-        return view_dir_world
-    else:
+    # only return a vector when viewing in 3D
+    if len(dims_displayed) == 2:
         return None
+        
+    tform = view.scene.transform
+    w, h = view.canvas.size
+
+    # get a point at the center of the canvas
+    # (homogeneous screen coords)
+    screen_center = np.array([w / 2, h / 2, 0, 1])
+
+    # find a point just in front of the center point
+    # transform both to world coords and find the vector
+    d1 = np.array([0, 0, 1, 0])
+    point_in_front_of_screen_center = screen_center + d1
+    p1 = tform.imap(point_in_front_of_screen_center)
+    p0 = tform.imap(screen_center)
+    d2 = p1 - p0
+
+    # in 3D world coordinates
+    d3 = d2[0:3]
+    d4 = d3 / np.linalg.norm(d3)
+
+    # data are ordered xyz on vispy Volume
+    d4 = d4[[2, 1, 0]]
+    view_dir_world = list(dims_point)
+    for i, d in enumerate(dims_displayed):
+        view_dir_world[d] = d4[i]
+
+    return view_dir_world

--- a/napari/components/cursor.py
+++ b/napari/components/cursor.py
@@ -27,6 +27,9 @@ class Cursor(EventedModel):
             * forbidden: A forbidden symbol
             * pointing: A finger for pointing
             * standard: The standard cursor
+    _view_direction : Optional[Tuple[float, ...]]
+        The vector describing the direction of the camera in the scene.
+        This is None when viewing in 2D.
     """
 
     # fields

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1012,7 +1012,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
             if world:
                 position = self.world_to_data(position)
             if dims_displayed is not None:
-                if (len(dims_displayed) == 2) or dims_displayed is None:
+                if len(dims_displayed) == 2:
                     value = self._get_value(position=tuple(position))
 
                 elif len(dims_displayed) == 3:

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1217,7 +1217,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
                     dims_displayed_mask
                 ]
             else:
-                view_dir = np.asarray(view_direction)
+                view_dir = np.asarray(view_direction)[dims_displayed_mask]
 
             # Get the clicked point in data coords (only displayed dims)
             if world is True:

--- a/napari/layers/labels/_tests/test_labels_mouse_bindings.py
+++ b/napari/layers/labels/_tests/test_labels_mouse_bindings.py
@@ -51,7 +51,7 @@ def test_paint(Event):
             type='mouse_press',
             is_dragging=False,
             position=(0, 0),
-            view_direction=(0, 1, 0),
+            view_direction=None,
             dims_displayed=(0, 1),
             dims_point=(0, 0),
         )
@@ -77,7 +77,7 @@ def test_paint(Event):
             type='mouse_release',
             is_dragging=False,
             position=(19, 19),
-            view_direction=(0, 1, 0),
+            view_direction=None,
             dims_displayed=(0, 1),
             dims_point=(0, 0),
         )
@@ -108,7 +108,7 @@ def test_paint_scale(Event):
             type='mouse_press',
             is_dragging=False,
             position=(0, 0),
-            view_direction=(0, 1, 0),
+            view_direction=None,
             dims_displayed=(0, 1),
             dims_point=(0, 0),
         )
@@ -121,7 +121,7 @@ def test_paint_scale(Event):
             type='mouse_move',
             is_dragging=True,
             position=(39, 39),
-            view_direction=(0, 1, 0),
+            view_direction=None,
             dims_displayed=(0, 1),
             dims_point=(0, 0),
         )
@@ -134,7 +134,7 @@ def test_paint_scale(Event):
             type='mouse_release',
             is_dragging=False,
             position=(39, 39),
-            view_direction=(0, 1, 0),
+            view_direction=None,
             dims_displayed=(0, 1),
             dims_point=(0, 0),
         )
@@ -165,7 +165,7 @@ def test_erase(Event):
             type='mouse_press',
             is_dragging=False,
             position=(0, 0),
-            view_direction=(0, 1, 0),
+            view_direction=None,
             dims_displayed=(0, 1),
             dims_point=(0, 0),
         )
@@ -178,7 +178,7 @@ def test_erase(Event):
             type='mouse_move',
             is_dragging=True,
             position=(19, 19),
-            view_direction=(0, 1, 0),
+            view_direction=None,
             dims_displayed=(0, 1),
             dims_point=(0, 0),
         )
@@ -191,7 +191,7 @@ def test_erase(Event):
             type='mouse_release',
             is_dragging=False,
             position=(19, 19),
-            view_direction=(0, 1, 0),
+            view_direction=None,
             dims_displayed=(0, 1),
             dims_point=(0, 0),
         )
@@ -223,7 +223,7 @@ def test_pick(Event):
             type='mouse_press',
             is_dragging=False,
             position=(0, 0),
-            view_direction=(0, 1, 0),
+            view_direction=None,
             dims_displayed=(0, 1),
             dims_point=(0, 0),
         )
@@ -237,7 +237,7 @@ def test_pick(Event):
             type='mouse_press',
             is_dragging=False,
             position=(19, 19),
-            view_direction=(1, 0, 0),
+            view_direction=None,
             dims_displayed=(0, 1),
             dims_point=(0, 0),
         )
@@ -266,7 +266,7 @@ def test_fill(Event):
             type='mouse_press',
             is_dragging=False,
             position=(0, 0),
-            view_direction=(0, 1, 0),
+            view_direction=None,
             dims_displayed=(0, 1),
             dims_point=(0, 0),
         )
@@ -285,7 +285,7 @@ def test_fill(Event):
             type='mouse_press',
             is_dragging=False,
             position=(19, 19),
-            view_direction=(0, 1, 0),
+            view_direction=None,
             dims_displayed=(0, 1),
             dims_point=(0, 0),
         )
@@ -342,7 +342,7 @@ def test_fill_nD_plane(Event):
             position=(0, 19, 19),
             view_direction=(1, 0, 0),
             dims_displayed=(0, 1),
-            dims_point=(0, 0),
+            dims_point=(0, 0, 0),
         )
     )
     mouse_press_callbacks(layer, event)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -938,14 +938,17 @@ class Labels(_ImageBase):
 
         Returns
         -------
-        value : Optional[int]
-            The first non-zero value encountered along the ray. If none
-            was encountered or the viewer is in 2D mode, None is returned.
+        value : int
+            The first non-zero value encountered along the ray. If a
+            non-zero value is not encountered, returns 0 (the background value).
         """
-        return self._get_value_ray(
-            start_point=start_position,
-            end_point=end_position,
-            dims_displayed=dims_displayed,
+        return (
+            self._get_value_ray(
+                start_point=start_position,
+                end_point=end_position,
+                dims_displayed=dims_displayed,
+            )
+            or 0
         )
 
     def _reset_history(self, event=None):


### PR DESCRIPTION
This PR modifies `view_direction` to be None when the viewer is in 2D mode. I think this also fixes the failing test.